### PR TITLE
Update Element.Name+.dyf

### DIFF
--- a/nodes/3.x/Element.Name+.dyf
+++ b/nodes/3.x/Element.Name+.dyf
@@ -60,8 +60,9 @@
     {
       "ConcreteType": "PythonNodeModels.PythonNode, PythonNodeModels",
       "NodeType": "PythonScriptNode",
-      "Code": "import clr\r\nimport System.IO\r\nclr.AddReference('RevitAPI')\r\nfrom Autodesk.Revit.DB import *\r\n\r\ndef GetName(item):\r\n\tunwrapped = UnwrapElement(item)\r\n\tif not unwrapped: return None\r\n\telif unwrapped.GetType().ToString() in (\"Autodesk.Revit.DB.Area\", \"Autodesk.Revit.DB.Architecture.TopographySurface\"):\r\n\t\ttry: return unwrapped.get_Parameter(BuiltInParameter.ROOM_NAME).AsString()\r\n\t\texcept: return unwrapped.Name\r\n\telif unwrapped.GetType().ToString() in (\"Autodesk.Revit.DB.BuiltInParameter\", \"Autodesk.Revit.DB.BuiltInParameterGroup\", \"Autodesk.Revit.DB.DisplayUnitType\", \"Autodesk.Revit.DB.ParameterType\", \"Autodesk.Revit.DB.UnitSymbolType\", \"Autodesk.Revit.DB.UnitType\"): \r\n\t\ttry: return LabelUtils.GetLabelFor(unwrapped)\r\n\t\texcept: return unwrapped.ToString()\r\n\telif unwrapped.GetType().ToString() in (\"Autodesk.Revit.DB.Parameter\", \"Autodesk.Revit.DB.FamilyParameter\"): return unwrapped.Definition.Name\r\n\telif unwrapped.GetType().ToString() == \"Revit.Application.Document\": \r\n\t\tif unwrapped.FilePath: return System.IO.Path.GetFileName(unwrapped.FilePath)\r\n\t\telse: return None\r\n\telif unwrapped.GetType().ToString() == (\"Autodesk.Revit.DB.ForgeTypeId\"): \r\n\t\ttry: return LabelUtils.GetLabelForSpec(unwrapped)\r\n\t\texcept: \r\n\t\t\ttry: return LabelUtils.GetLabelForSymbol(unwrapped)\r\n\t\t\texcept: \r\n\t\t\t\ttry: return LabelUtils.GetLabelForUnit(unwrapped)\r\n\t\t\t\texcept: \r\n\t\t\t\t\ttry: return LabelUtils.GetLabelForGroup(unwrapped)\r\n\t\t\t\t\texcept: \r\n\t\t\t\t\t\ttry: return LabelUtils.GetLabelForBuiltinParameter(unwrapped)\r\n\t\t\t\t\t\texcept: \r\n\t\t\t\t\t\t\ttry: return LabelUtils.GetLabelForDiscipline(unwrapped)\r\n\t\t\t\t\t\t\texcept: return unwrapped.TypeId\t\t\t\r\n\telif hasattr(unwrapped, \"GetName\"): return unwrapped.GetName()\r\n\telif hasattr(unwrapped, \"Name\"): return unwrapped.Name\r\n\telif hasattr(item, \"Name\"): return item.Name\r\n\telse: return None\r\n\r\nitems = IN[0]\r\nif isinstance(IN[0], list): OUT = [GetName(x) for x in IN[0]]\r\nelse: OUT = GetName(IN[0])",
+      "Code": "import clr\r\nimport System.IO\r\nimport System\r\nclr.AddReference('RevitAPI')\r\nfrom Autodesk.Revit.DB import LabelUtils, BuiltInParameter\r\n\r\ndef GetName(item):\r\n\tunwrapped = UnwrapElement(item)\r\n\telementClass = unwrapped.__class__\r\n\tif not unwrapped: return None\r\n\telif elementClass in (\"Autodesk.Revit.DB.Area\", \"Autodesk.Revit.DB.Architecture.TopographySurface\"):\r\n\t\ttry: return unwrapped.get_Parameter(BuiltInParameter.ROOM_NAME).AsString()\r\n\t\texcept: return unwrapped.Name\r\n\telif elementClass in (\"Autodesk.Revit.DB.BuiltInParameter\", \"Autodesk.Revit.DB.BuiltInParameterGroup\", \"Autodesk.Revit.DB.DisplayUnitType\", \"Autodesk.Revit.DB.ParameterType\", \"Autodesk.Revit.DB.UnitSymbolType\", \"Autodesk.Revit.DB.UnitType\"): \r\n\t\ttry: return LabelUtils.GetLabelFor(unwrapped)\r\n\t\texcept: return unwrapped.ToString()\r\n\telif elementClass in (\"Autodesk.Revit.DB.Parameter\", \"Autodesk.Revit.DB.FamilyParameter\"): return unwrapped.Definition.Name\r\n\telif elementClass == \"Revit.Application.Document\": \r\n\t\tif unwrapped.FilePath: return System.IO.Path.GetFileName(unwrapped.FilePath)\r\n\t\telse: return None\r\n\telif elementClass == (\"Autodesk.Revit.DB.ForgeTypeId\"): \r\n\t\ttry: return LabelUtils.GetLabelForSpec(unwrapped)\r\n\t\texcept: \r\n\t\t\ttry: return LabelUtils.GetLabelForSymbol(unwrapped)\r\n\t\t\texcept: \r\n\t\t\t\ttry: return LabelUtils.GetLabelForUnit(unwrapped)\r\n\t\t\t\texcept: \r\n\t\t\t\t\ttry: return LabelUtils.GetLabelForGroup(unwrapped)\r\n\t\t\t\t\texcept: \r\n\t\t\t\t\t\ttry: return LabelUtils.GetLabelForBuiltinParameter(unwrapped)\r\n\t\t\t\t\t\texcept: \r\n\t\t\t\t\t\t\ttry: return LabelUtils.GetLabelForDiscipline(unwrapped)\r\n\t\t\t\t\t\t\texcept: return unwrapped.TypeId\t\t\t\r\n\telif hasattr(unwrapped, \"GetName\"): return unwrapped.GetName()\r\n\telif hasattr(unwrapped, \"Name\"): return unwrapped.Name\r\n\telif hasattr(item, \"Name\"): return item.Name\r\n\telse: return None\r\n\r\nitems = IN[0]\r\nif isinstance(IN[0], list): OUT = [GetName(x) for x in IN[0]]\r\nelse: OUT = GetName(IN[0])",
       "Engine": "CPython3",
+      "EngineName": "CPython3",
       "VariableInputPorts": true,
       "Id": "fe1345c4af284ad48eee6a5bbea61e11",
       "Inputs": [
@@ -94,12 +95,14 @@
     {
       "Start": "d06c16cc87214d6091c7c8e933b4ee70",
       "End": "a107bd83a9494493b39350f2efb8c8a7",
-      "Id": "0a79e25a7b5c4b0fa25093f4290057e7"
+      "Id": "0a79e25a7b5c4b0fa25093f4290057e7",
+      "IsHidden": "False"
     },
     {
       "Start": "816331c8c1164322b5a06633c1b7c08b",
       "End": "d4435d44a874460591b308734765747e",
-      "Id": "bd65b8a3d35749e68a566566e4aa71c7"
+      "Id": "bd65b8a3d35749e68a566566e4aa71c7",
+      "IsHidden": "False"
     }
   ],
   "Dependencies": [],
@@ -111,7 +114,7 @@
       "ScaleFactor": 1.0,
       "HasRunWithoutCrash": false,
       "IsVisibleInDynamoLibrary": true,
-      "Version": "2.12.1.8246",
+      "Version": "2.16.2.5624",
       "RunType": "Manual",
       "RunPeriod": "1000"
     },
@@ -127,10 +130,11 @@
       "UpY": 1.0,
       "UpZ": 0.0
     },
+    "ConnectorPins": [],
     "NodeViews": [
       {
-        "ShowGeometry": true,
         "Name": "Input",
+        "ShowGeometry": true,
         "Id": "87f38510c9e94c958119d85d995c924f",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -139,8 +143,8 @@
         "Y": 138.37285610201076
       },
       {
-        "ShowGeometry": true,
         "Name": "Output",
+        "ShowGeometry": true,
         "Id": "8f1bdb124403406c90d67cefe95d4b2d",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,
@@ -149,8 +153,8 @@
         "Y": 138.37285610201076
       },
       {
-        "ShowGeometry": true,
         "Name": "Python Script",
+        "ShowGeometry": true,
         "Id": "fe1345c4af284ad48eee6a5bbea61e11",
         "IsSetAsInput": false,
         "IsSetAsOutput": false,


### PR DESCRIPTION
### Purpose
Type.GetType does not work in Revit 2025. See relevant Issue: #440
Document.Element Classes has as output null. It's because item.GetType() does not work in CPython3. `item.__class__` would fix the issue.


### Housekeeping
- [x] I am running the *latest available version* of Clockwork
